### PR TITLE
ts-jest と Babel プラグインを一緒に使えるようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "setupFilesAfterEnv": [
       "<rootDir>/test.config.js"
     ],
+    "globals": {
+      "ts-jest": {
+        "babelConfig": true
+      }
+    },
     "transform": {
       "^.+\\.js$": "babel-jest",
       "^.+\\.(ts|tsx)$": "ts-jest"


### PR DESCRIPTION
ただ単に`ts-jest`を導入すると、Babel プラグインが使えなくなってしまう。
具体的には、`babel-preset-power-assert`が機能しなくなっていた。

以下の公式ページの内容に従って修正した。
https://kulshekhar.github.io/ts-jest/user/config/babelConfig