### PR TITLE
@typescript/eslint の recommended rules を導入する

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,9 @@
 {
-  "extends": "numb",
+  "extends": [
+    "numb",
+    "plugin:@typescript-eslint/recommended",
+    "prettier/@typescript-eslint"
+  ],
   "parser": "@typescript-eslint/parser",
   "plugins": [
     "@typescript-eslint"

--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,7 @@
     "@typescript-eslint/explicit-function-return-type": [
       "warn",
       {"allowTypedFunctionExpressions": true}
-    ]
+    ],
+    "@typescript-eslint/no-explicit-any": "off"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,10 @@
   },
   "rules": {
     "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": "error"
+    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/explicit-function-return-type": [
+      "warn",
+      {"allowTypedFunctionExpressions": true}
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.0",
     "whatwg-fetch": "^3.0.0"
+  },
+  "resolutions": {
+    "@types/react": "^16.8.19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.13.2",
     "eslint": "^5.16.0",
-    "eslint-config-numb": "^5.1.0",
+    "eslint-config-numb": "^6.0.0",
     "html-webpack-plugin": "^3.2.0",
     "jest": "^24.7.1",
     "license-info-webpack-plugin": "^2.0.0",

--- a/src/hooks/components/App.tsx
+++ b/src/hooks/components/App.tsx
@@ -3,7 +3,12 @@ import React, {useReducer} from 'react';
 import SelectBox from './SelectBox';
 import TextBox from './TextBox';
 
-const mockApi = (value: any) => Promise.resolve(value);
+interface Fruit {
+  id: number;
+  label: string;
+}
+
+const mockApi = (value: number): Promise<number> => Promise.resolve(value);
 
 const fruitList = [
   {id: 1, label: 'Banana'},
@@ -11,13 +16,15 @@ const fruitList = [
   {id: 3, label: 'Orange'},
 ];
 
-const App = ({reducer, initialState}: any) => {
+const App = ({reducer, initialState}: any): React.ReactElement => {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const onSelectFruit = (e: any) => {
-    const seletedFruit = fruitList.filter(f => f.label === e.target.value)[0];
+  const onSelectFruit = (e: React.FormEvent<HTMLSelectElement>): void => {
+    const seletedFruit = fruitList.filter(
+      (f: Fruit): boolean => f.label === e.currentTarget.value
+    )[0];
     dispatch({type: 'UPDATE_FAVORITE_FRUIT', favoriteFruit: seletedFruit});
   };
-  const increment = async (value: any) => {
+  const increment = async (value: number): Promise<void> => {
     const res = await mockApi(value);
     dispatch({type: 'INCREMENT', incrementValue: res});
   };
@@ -34,12 +41,12 @@ const App = ({reducer, initialState}: any) => {
         {favoriteFruit && `I like ${favoriteFruit.label}.`}
       </div>
 
-      <button type="button" onClick={() => increment(1)}>
+      <button type="button" onClick={(): Promise<void> => increment(1)}>
         +1
       </button>
 
       <SelectBox
-        list={fruitList.map(f => f.label)}
+        list={fruitList.map((f: Fruit): string => f.label)}
         selectedItem={favoriteFruit ? favoriteFruit.label : null}
         onChange={onSelectFruit}
         initialMessage="select favorite fruit"
@@ -50,10 +57,10 @@ const App = ({reducer, initialState}: any) => {
       <TextBox
         type="text"
         value={screenName}
-        onChange={(e: any) => {
+        onChange={(e: React.FormEvent<HTMLInputElement>): void => {
           dispatch({
             type: 'ENTER_SCREEN_NAME',
-            screenName: e.target.value,
+            screenName: e.currentTarget.value,
           });
         }}
         placeHolder="Enter your name"
@@ -65,10 +72,10 @@ const App = ({reducer, initialState}: any) => {
       <TextBox
         type="password"
         value={message}
-        onChange={(e: any) => {
+        onChange={(e: React.FormEvent<HTMLInputElement>): void => {
           dispatch({
             type: 'ENTER_MESSAGE',
-            message: e.target.value,
+            message: e.currentTarget.value,
           });
         }}
         placeHolder="Enter message"

--- a/src/hooks/components/SelectBox.tsx
+++ b/src/hooks/components/SelectBox.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 
-const SelectBox = ({
+interface Props {
+  list: string[];
+  selectedItem: string;
+  onChange: (arg: React.FormEvent<HTMLSelectElement>) => any;
+  initialMessage?: string;
+  className?: string;
+}
+
+const SelectBox: React.FC<Props> = ({
   list,
   selectedItem,
   onChange,
   initialMessage = '',
   className,
-}: any) => (
+}) => (
   <select
     value={selectedItem || initialMessage}
     onChange={onChange}
@@ -18,11 +26,13 @@ const SelectBox = ({
       </option>
     )}
     {list &&
-      list.map((item: any) => (
-        <option key={item} value={item}>
-          {item}
-        </option>
-      ))}
+      list.map(
+        (item: string): React.ReactElement => (
+          <option key={item} value={item}>
+            {item}
+          </option>
+        )
+      )}
   </select>
 );
 export default SelectBox;

--- a/src/hooks/components/TextBox.tsx
+++ b/src/hooks/components/TextBox.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-const TextBox = ({
+// TODO: 完全に無意味なコンポーネントなので、あとで削除する
+const TextBox: (arg: any) => React.ReactElement = ({
   type,
   value,
   onChange,

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -3,12 +3,14 @@ import ReactDOM from 'react-dom';
 
 import App from './components/App';
 
-const reducer = (state: any, action: any) => {
+const reducer = (state: any, action: any): {} => {
   const actionValues = Object.values(action);
-  actionValues.forEach(v => {
-    if (v instanceof Promise)
-      throw new Error('Action does not allow Promise Object.');
-  });
+  actionValues.forEach(
+    (v): void => {
+      if (v instanceof Promise)
+        throw new Error('Action does not allow Promise Object.');
+    }
+  );
 
   const {type, favoriteFruit, incrementValue, screenName, message} = action;
   switch (type) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,13 +11,13 @@ const z = {
 };
 console.log(z);
 
-const asyncFunc = async () => {
+const asyncFunc = async (): Promise<void> => {
   const res = await fetch('http://localhost:8080');
   console.log(res.status);
 };
 
 asyncFunc();
 
-const App = () => <>Hello React!</>;
+const App: () => React.ReactElement = () => <>Hello React!</>;
 
 ReactDOM.render(<App />, document.querySelector('#app'));

--- a/src/routing/components/App.tsx
+++ b/src/routing/components/App.tsx
@@ -6,7 +6,7 @@ import Home from './Home';
 import Memo from './Memo';
 import Profile from './Profile';
 
-const App = () => (
+const App: () => React.ReactElement = () => (
   <BrowserRouter>
     <>
       <Header />

--- a/src/routing/components/Header.tsx
+++ b/src/routing/components/Header.tsx
@@ -8,13 +8,15 @@ const links = [
   {path: '/routing/profile', text: 'Profile'},
 ];
 
-const Header = () => (
+const Header: () => React.ReactElement = () => (
   <>
-    {links.map(link => (
-      <div key={link.path}>
-        <Link to={link.path}>{link.text}</Link>
-      </div>
-    ))}
+    {links.map(
+      (link): React.ReactElement => (
+        <div key={link.path}>
+          <Link to={link.path}>{link.text}</Link>
+        </div>
+      )
+    )}
     <hr />
   </>
 );

--- a/src/routing/components/Home.tsx
+++ b/src/routing/components/Home.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const Home = () => (
+const Home: () => React.ReactElement = () => (
   <>
     Home<div data-test="text">This page is home.</div>
   </>

--- a/src/routing/components/Memo.tsx
+++ b/src/routing/components/Memo.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import {Route} from 'react-router-dom';
 
-const Memo = () => (
+const Memo: () => React.ReactElement = () => (
   <>
     Memo
-    <Route path="/routing/memo/hoge" render={() => <div>Hoge</div>} />
+    <Route
+      path="/routing/memo/hoge"
+      render={(): React.ReactElement => <div>Hoge</div>}
+    />
   </>
 );
 export default Memo;

--- a/src/routing/components/Profile.tsx
+++ b/src/routing/components/Profile.tsx
@@ -1,4 +1,4 @@
 import React from 'react';
 
-const Profile = () => <>Profile</>;
+const Profile: () => React.ReactElement = () => <>Profile</>;
 export default Profile;

--- a/src/routing/components/__tests__/Home.test.tsx
+++ b/src/routing/components/__tests__/Home.test.tsx
@@ -4,8 +4,8 @@ import assert from 'assert';
 
 import Home from '../Home';
 
-describe('Home', () => {
-  it('テキストは Home', () => {
+describe('Home', (): void => {
+  it('テキストは Home', (): void => {
     const wrapper: ShallowWrapper = shallow(<Home />).find(
       '[data-test="text"]'
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,15 +1046,7 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react@*":
-  version "16.8.17"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.17.tgz#f287b76a5badb93bc9aa3f54521a3eb53d6c2374"
-  integrity sha512-pln3mgc6VfkNg92WXODul/ONo140huK9OMsx62GlBlZ2lvjNK86PQJhYMPLO1i66aF5O9OPyZefogvNltBIszA==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
-"@types/react@^16.8.19":
+"@types/react@*", "@types/react@^16.8.19":
   version "16.8.19"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.19.tgz#629154ef05e2e1985cdde94477deefd823ad9be3"
   integrity sha512-QzEzjrd1zFzY9cDlbIiFvdr+YUmefuuRYrPxmkwG0UQv5XF35gFIi7a95m1bNVcFU0VimxSZ5QVGSiBmlggQXQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2962,14 +2962,14 @@ eslint-config-airbnb@^17.1.0:
     object.assign "^4.1.0"
     object.entries "^1.0.4"
 
-eslint-config-numb@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-numb/-/eslint-config-numb-5.1.0.tgz#bbe1c8a37847a5642161aae0a4c29c65c15dcb00"
-  integrity sha512-yzK69R6Wxjn4dsgtyCcKZi3t02aKeUdB6xr3J0jegQwTBKmavgYJpqiBEFFbL+he/KHeO1q7wNnazgkWqRfXCg==
+eslint-config-numb@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-numb/-/eslint-config-numb-6.0.0.tgz#d9823c77287fca01f9070b6d221dbb89de01d2ad"
+  integrity sha512-Qq7pdaYMybII3LIXR2CbX2Uah1A7MebuFKtn9IFeeHO+hwrW7Xm9j9UQiyZPR49FUzjquBuryj9Kvty4FGEXPg==
   dependencies:
     eslint "^5.9.0"
     eslint-config-airbnb "^17.1.0"
-    eslint-config-prettier "^3.6.0"
+    eslint-config-prettier "^4.3.0"
     eslint-plugin-import "^2.17.2"
     eslint-plugin-jsx-a11y "^6.2.1"
     eslint-plugin-prettier "^3.0.1"
@@ -2977,10 +2977,10 @@ eslint-config-numb@^5.1.0:
     eslint-plugin-react-hooks "^1.6.0"
     prettier "^1.17.0"
 
-eslint-config-prettier@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-3.6.0.tgz#8ca3ffac4bd6eeef623a0651f9d754900e3ec217"
-  integrity sha512-ixJ4U3uTLXwJts4rmSVW/lMXjlGwCijhBJHk8iVqKKSifeI0qgFEfWl8L63isfc8Od7EiBALF6BX3jKLluf/jQ==
+eslint-config-prettier@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.3.0.tgz#c55c1fcac8ce4518aeb77906984e134d9eb5a4f0"
+  integrity sha512-sZwhSTHVVz78+kYD3t5pCWSYEdVSBR0PXnwjDRsUs8ytIrK8PLXw+6FKp8r3Z7rx4ZszdetWlXYKOHoUrrwPlA==
   dependencies:
     get-stdin "^6.0.0"
 


### PR DESCRIPTION
主な変更点。

### plugin:@typescript-eslint/recommended の導入

- 「取り敢えず`any`で逃げる」という運用が出来ないのは厳しいので、`@typescript-eslint/no-explicit-any`は無効にした。
- 今回のPRではまだ使っていないが、関数の型定義の再利用をしたかったので、`allowTypedFunctionExpressions`オプションを有効にした。

### prettier/@typescript-eslint の導入

- ` prettier/@typescript-eslint`のルールと`prettier`を一緒に使うため
  - `eslint-config-prettier`が`4.0.0`以降である必要があるので、`eslint-config-numb`のバージョンを上げた

### TypeScript のエラーの解消

今回の変更でなぜか、TypeScript のエラーが出るようになってしまった。
`yarn.lock`に記述されているライブラリの依存関係が上手く解決できていないのが原因の模様。
取り敢えず以下の記事を参考に`package.json`の`resolutions`セクションを追加して解決したが、よく分かっていない。
[reactjs - TypeScript: Duplicate identifier &#39;LibraryManagedAttributes&#39; - Stack Overflow](https://stackoverflow.com/questions/52399839/typescript-duplicate-identifier-librarymanagedattributes)
